### PR TITLE
feat: Implement hardcoded admin login

### DIFF
--- a/app/src/main/java/com/example/uiprototypebeta/AdminLoginActivity.kt
+++ b/app/src/main/java/com/example/uiprototypebeta/AdminLoginActivity.kt
@@ -4,8 +4,10 @@ import android.content.Intent
 import android.os.Bundle
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
+// Import statement for view binding - THIS WAS THE BROKEN LINE
 import com.example.uiprototypebeta.databinding.ActivityAdminLoginBinding
 
+// Class definition starts here, on a NEW LINE
 class AdminLoginActivity : AppCompatActivity() {
     private lateinit var binding: ActivityAdminLoginBinding
 
@@ -14,13 +16,29 @@ class AdminLoginActivity : AppCompatActivity() {
         binding = ActivityAdminLoginBinding.inflate(layoutInflater)
         setContentView(binding.root)
 
+        // This is for the back/close button
         binding.toolbar.setNavigationOnClickListener { finish() }
 
+        // --- LOGIN BUTTON LOGIC ---
         binding.btnAdminLogin.setOnClickListener {
-            // Placeholder interaction until real authentication is wired in
-            Toast.makeText(this, "Admin login UI only", Toast.LENGTH_SHORT).show()
+            // Get text using the CORRECT IDs from your XML file
+            val username = binding.etEmail.text.toString()
+            val password = binding.etPassword.text.toString()
+
+            // Hardcoded check for "admin" and "123"
+            if (username == "admin" && password == "123") {
+                // If correct, show success and navigate
+                Toast.makeText(this, "Login Successful!", Toast.LENGTH_SHORT).show()
+                val intent = Intent(this, AdminDashboardActivity::class.java)
+                startActivity(intent)
+                finish()
+            } else {
+                // If wrong, show an error
+                Toast.makeText(this, "Invalid credentials", Toast.LENGTH_LONG).show()
+            }
         }
 
+        // This button logic is correct
         binding.btnSwitchToUser.setOnClickListener {
             startActivity(Intent(this, LoginActivity::class.java))
             finish()


### PR DESCRIPTION
This pull request implements the login functionality for the Admin Login screen.

- Adds a hardcoded credential check for username "admin" and password "123".
- On successful login, the user is redirected to the `AdminDashboardActivity`.
- An error message is displayed for invalid credentials.

This change allows access to the admin dashboard for development and testing purposes.
